### PR TITLE
Fix to allow daemon detection in ES

### DIFF
--- a/daemon/usr/bin/picadehatd
+++ b/daemon/usr/bin/picadehatd
@@ -103,7 +103,7 @@ gpio.setup(BUTTONS, gpio.IN, pull_up_down=gpio.PUD_UP)
 gpio.setup(BUTTON_POWER, gpio.IN, pull_up_down=gpio.PUD_UP)
 
 try:
-    ui = UInput()
+    ui = UInput({e.EV_KEY: KEYS.values()}, name="Picade-HAT", bustype=e.BUS_USB)
 
 except uinput.UInputError as e:
     sys.stdout.write(e.message)


### PR DESCRIPTION
This fix is in response to this forum post: http://forums.pimoroni.com/t/picade-hat-joystick-not-detected-w-out-usb-keyboard-plugged-in/3704

User discovered that Picadehatd input isn't detected by EmulationStation unless a keyboard is plugged in. I've updated the `UInput` initialization to ensure it sets up a virtual device. It seems to create `/dev/input/event0` on my system with this change, Previously keyboard events were raised to the system, but EmulationStation didn't detect or attempt to handle any keyboard input.