### PR TITLE
Refined asound.conf

### DIFF
--- a/daemon/etc/asound.conf
+++ b/daemon/etc/asound.conf
@@ -1,11 +1,9 @@
-# the sound card
 pcm.real {
   type hw
   card 0
   device 0
 }
 
-#support  the ipc stuff is needed for permissions, etc.
 pcm.dmixer {
   type dmix
   ipc_key 1024
@@ -28,34 +26,16 @@ ctl.dmixer {
   card 0
 }
 
-# software volume
 pcm.softvol {
   type softvol
   slave.pcm "dmixer"
   control {
-    name "PCM"
+    name "PCM" # Masquerade as the default "PCM" sound device on Pi (for EmulationStation)
     card 0
    }
 }
 
-# input
-pcm.input {
-   type dsnoop
-   ipc_key 3129398
-   ipc_key_add_uid false
-   ipc_perm 0660
-   slave.pcm "810"
-}
-
-# duplex device
-pcm.duplex {
-   type asym
-   playback.pcm "softvol"
-   capture.pcm "input"
-}
-
-# default devices
 pcm.!default {
    type plug
-   slave.pcm "duplex"
+   slave.pcm "softvol"
 }


### PR DESCRIPTION
Tweaks from @sandyjmacdonald to remove full-duplex support from asound.conf. Previously contained support for audio input that isn't present on Picade HAT. I've also dropped the unnecessary comments and explained why the software volume is named "PCM" - it's so that EmulationStation thinks it's just the regular "PCM" sound device on the Raspberry Pi and doesn't complain.