### PR TITLE
Allow pi-topOS

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -36,7 +36,7 @@ armv6="yes" # whether armv6 processors are supported
 armv7="yes" # whether armv7 processors are supported
 armv8="yes" # whether armv8 processors are supported
 raspbianonly="no" # whether the script is allowed to run on other OSes
-osreleases=( "Raspbian" "RetroPie" ) # list os-releases supported
+osreleases=( "Raspbian" "RetroPie" "PiTop" ) # list os-releases supported
 oswarning=() # list experimental os-releases
 osdeny=( "Darwin" "Debian" "Kali" "Kano" "Mate" "Ubuntu" ) # list os-releases specifically disallowed
 

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ armv8="yes" # whether armv8 processors are supported
 raspbianonly="no" # whether the script is allowed to run on other OSes
 osreleases=( "Raspbian" "RetroPie" ) # list os-releases supported
 oswarning=() # list experimental os-releases
-osdeny=( "Darwin" "Debian" "Kali" "Kano" "Mate" "PiTop" "Ubuntu" ) # list os-releases specifically disallowed
+osdeny=( "Darwin" "Debian" "Kali" "Kano" "Mate" "Ubuntu" ) # list os-releases specifically disallowed
 
 FORCE=$1
 DEVICE_TREE=true


### PR DESCRIPTION
As the main developer responsible for pi-topOS, I can confirm that it *is* Raspbian under-the-hood, and this scripts works just fine with it. It would be nice for users to be able to use this script directly rather than having to modify it to make it run on a platform that will support it.