### PR TITLE
Enable HDMI hot-plug on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ ASOUND_CONF_FILE="etc/asound.conf"
 CONFIG_LINES=(
 	"dtoverlay=picade"
 	"dtparam=audio=off"
+	"hdmi_force_hotplug=1"
 )
 
 printf "Picade HAT: Installer\n\n"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,6 +9,7 @@ CONFIG_BACKUP="$CONFIG.picade-preuninstall"
 CONFIG_LINES=(
 	"dtoverlay=picade"
 	"dtparam=audio=off"
+	"hdmi_force_hotplug=1"
 )
 
 printf "Picade HAT: Uninstaller\n\n"


### PR DESCRIPTION
This PR enables HDMI hot-plug on install (and removes it on uninstall), to ensure displays which are powered directly from the Raspberry Pi are picked up successfully after the Pi has booted.