### PR TITLE
Add a newline before config.txt insertions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,15 +58,22 @@ else
 fi
 
 if [ -f "$CONFIG" ]; then
+	NEWLINE=0
 	for ((i = 0; i < ${#CONFIG_LINES[@]}; i++)); do
 		CONFIG_LINE="${CONFIG_LINES[$i]}"
 		grep -e "^#$CONFIG_LINE" $CONFIG > /dev/null
 		STATUS=$?
 		if [ $STATUS -eq 1 ]; then
-			grep -r "^$CONFIG_LINE" $CONFIG > /dev/null
+			grep -e "^$CONFIG_LINE" $CONFIG > /dev/null
 			STATUS=$?
 			if [ $STATUS -eq 1 ]; then
 				# Line is missing from config file
+				if [ ! $NEWLINE -eq 1 ]; then
+					# Add newline if this is the first new entry
+					echo "" >> $CONFIG
+					NEWLINE=1
+				fi
+				# Add the config line
 				echo "$CONFIG_LINE" >> $CONFIG
 				printf "Config: Added \"$CONFIG_LINE\" to $CONFIG\n"
 			else

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,7 +9,6 @@ CONFIG_BACKUP="$CONFIG.picade-preuninstall"
 CONFIG_LINES=(
 	"dtoverlay=picade"
 	"dtparam=audio=off"
-	"hdmi_force_hotplug=1"
 )
 
 printf "Picade HAT: Uninstaller\n\n"


### PR DESCRIPTION
This prevents a case where, if the file does not end with a newline, config lines were concatenated onto the end of the previous line, and not being recognised.